### PR TITLE
fix double free memory 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ endif()
 set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_SOURCE_DIR}/postinst;")
 set(CPACK_GENERATOR "DEB")
 ## Set the package version
-set(CPACK_PACKAGE_VERSION "1.3.13")
+set(CPACK_PACKAGE_VERSION "1.3.14")
 # Set the package name
 set(CPACK_PACKAGE_NAME "neuron-library")
 # Set the package file format

--- a/src/x86/x86.c
+++ b/src/x86/x86.c
@@ -128,7 +128,7 @@ mraa_x86_platform()
         
         if (file_hold != NULL) {
             if (getline(&line, &len, file_hold) != -1) {
-		
+		line[strcspn(line, "\r\n")] = 0;
                 if (strncmp(line, "ROScube-I", strlen("ROScube-I")) == 0 ) {
                     // includes ROScube-I, ROScube-I ET
                     platform_type = MRAA_ADLINK_ROSCUBE_I;

--- a/src/x86/x86.c
+++ b/src/x86/x86.c
@@ -102,7 +102,10 @@ mraa_x86_platform()
             } else {
                 platform_type = MRAA_UNKNOWN_PLATFORM;
             }
+            
             free(line);
+	    line = NULL;
+            
         }
         fclose(fh);
     } else {
@@ -114,17 +117,19 @@ mraa_x86_platform()
                     plat = mraa_intel_sofia_3gr();
                 }
                 free(line);
-            }
+		line = NULL;
+	 }
             fclose(fh);
         }
     }
+ 
     if (platform_type == MRAA_UNKNOWN_PLATFORM){
         FILE* file_hold = fopen("/sys/devices/virtual/dmi/id/product_name", "r");
-        char* platform_name = NULL;
+        
         if (file_hold != NULL) {
-            if (getline(&platform_name, &len, file_hold) != -1) {
-                platform_name[strcspn(platform_name, "\r\n")] = 0;
-                if (strncmp(platform_name, "ROScube-I", strlen("ROScube-I")) == 0 ) {
+            if (getline(&line, &len, file_hold) != -1) {
+		
+                if (strncmp(line, "ROScube-I", strlen("ROScube-I")) == 0 ) {
                     // includes ROScube-I, ROScube-I ET
                     platform_type = MRAA_ADLINK_ROSCUBE_I;
                     plat = mraa_roscube_i();
@@ -132,7 +137,9 @@ mraa_x86_platform()
                     syslog(LOG_ERR, "Platform not supported, not initialising");
                     platform_type = MRAA_UNKNOWN_PLATFORM;
                 }
-                free(platform_name);
+                
+                free(line);
+		 line = NULL;
             }
             fclose(file_hold);
         }

--- a/src/x86/x86.c
+++ b/src/x86/x86.c
@@ -120,10 +120,11 @@ mraa_x86_platform()
     }
     if (platform_type == MRAA_UNKNOWN_PLATFORM){
         FILE* file_hold = fopen("/sys/devices/virtual/dmi/id/product_name", "r");
+        char* platform_name = NULL;
         if (file_hold != NULL) {
-            if (getline(&line, &len, file_hold) != -1) {
-                line[strcspn(line, "\r\n")] = 0;
-                if (strncmp(line, "ROScube-I", strlen("ROScube-I")) == 0 ) {
+            if (getline(&platform_name, &len, file_hold) != -1) {
+                platform_name[strcspn(platform_name, "\r\n")] = 0;
+                if (strncmp(platform_name, "ROScube-I", strlen("ROScube-I")) == 0 ) {
                     // includes ROScube-I, ROScube-I ET
                     platform_type = MRAA_ADLINK_ROSCUBE_I;
                     plat = mraa_roscube_i();
@@ -131,7 +132,7 @@ mraa_x86_platform()
                     syslog(LOG_ERR, "Platform not supported, not initialising");
                     platform_type = MRAA_UNKNOWN_PLATFORM;
                 }
-                free(line);
+                free(platform_name);
             }
             fclose(file_hold);
         }


### PR DESCRIPTION
To avoid the error :  "free(): double free detected in tache2"  when using pyqt and mraa  in simulation. 